### PR TITLE
Add new setting `pillarExtraMigrationsDirs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ pillarReplicationFactorConfigKey := "cassandra.replicationFactor"
 pillarDefaultConsistencyLevelConfigKey := "cassandra.defaultConsistencyLevel"
 
 pillarMigrationsDir := file("conf/migrations")
+
+//optionally:
+pillarExtraMigrationsDirs := Seq(file("conf/extra-migrations"))
 ```
 
 The shown configuration assumes that the url for your cassandra is configured in `conf/application.conf` under the key
@@ -45,9 +48,10 @@ check out the [pillar documentation](https://github.com/comeara/pillar#migration
 The `cassandra.url` has to follow the format `cassandra://<host>:<port>/<keyspace>?host=<host>&host=<host>`, e.g. it would be
 `cassandra.url="cassandra://192.168.0.10:9042/my_keyspace?host=192.168.0.11&host=192.168.0.12"`.
 
-The `pillarReplicationStrategyConfigKey` is optional, the default value is `SimpleStrategy`. 
-The `pillarReplicationFactorConfigKey` is optional, the default value is `3`. 
+The `pillarReplicationStrategyConfigKey` is optional, the default value is `SimpleStrategy`.
+The `pillarReplicationFactorConfigKey` is optional, the default value is `3`.
 The `pillarDefaultConsistencyLevelConfigKey` is optional, the default value is `QUORUM`.
+The `pillarExtraMigrationsDirs` is optional, the default is `Seq.empty`.  Here you can add directories containing extra migration files, which will be processed in addition to the ones in `pillarMigrationsDir`.
 
 ## Usage
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ description := "sbt plugin for cassandra schema/data migrations using pillar (ht
 
 organization := "io.ino"
 
-version := "2.0.0"
+version := "2.1.0"
 
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 


### PR DESCRIPTION
Adds a new plugin setting for `pillarExtraMigrationsDirs`, allowing you to specify a list of migration directories, which are processed in the given order in addition to the primary `pillarMigrationsDir`.  

The use case is that you might want to have a common set of migrations and in addition to that one (or theoretically more) directory where deployment specific migrations are located.

I also assumed that the bumped version should be `2.1.0` because it is not a bug fix, does not make any breaking changes, but adds a new feature.