### PR TITLE
Fix bug if list files contains directory/ies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The plugin is built for sbt 0.13.
 
 To install the plugin you have to add it to `project/plugins.sbt`:
 ```
-addSbtPlugin("io.ino" %% "sbt-pillar-plugin" % "2.1.0")
+addSbtPlugin("io.ino" %% "sbt-pillar-plugin" % "2.1.1")
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ check out the [pillar documentation](https://github.com/comeara/pillar#migration
 The `cassandra.url` has to follow the format `cassandra://<host>:<port>/<keyspace>?host=<host>&host=<host>`, e.g. it would be
 `cassandra.url="cassandra://192.168.0.10:9042/my_keyspace?host=192.168.0.11&host=192.168.0.12"`.
 
+The `pillarMigrationsDir` contains the directory with the cql-files to process. There would be read recursively through all folders in this directory.
+
 The `pillarReplicationStrategyConfigKey` is optional, the default value is `SimpleStrategy`.
 
 The `pillarReplicationFactorConfigKey` is optional, the default value is `3`.

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ description := "sbt plugin for cassandra schema/data migrations using pillar (ht
 
 organization := "io.ino"
 
-version := "2.1.0"
+version := "2.1.1"
 
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 

--- a/src/main/scala/io/ino/sbtpillar/Plugin.scala
+++ b/src/main/scala/io/ino/sbtpillar/Plugin.scala
@@ -220,9 +220,9 @@ object Plugin extends sbt.Plugin {
 
     private def loadMigrations(migrationsDir: File) = {
       val parser = de.kaufhof.pillar.Parser()
-      val fileList: Seq[File] = getFilesRecursivelyThroughFolders(migrationsDir,Seq.empty[File])
-      if (fileList.nonEmpty) {
-        fileList map {file =>
+      val files: Seq[File] = getFilesFromMainAndAllSubFolders(migrationsDir)
+      if (files.nonEmpty) {
+        files map {file =>
           val in = Files.newInputStream(file.toPath)
           try {
             parser.parse(in)
@@ -235,17 +235,7 @@ object Plugin extends sbt.Plugin {
       }
     }
 
-    private def getFilesRecursivelyThroughFolders(file: File, seqFiles: Seq[File]): Seq[File] = {
-      Option(file.listFiles()) match {
-        case Some(files: Array[File]) =>
-          files flatMap {
-            case f: File if f.isDirectory => getFilesRecursivelyThroughFolders(f, seqFiles)
-            case f: File =>  seqFiles :+ f
-            case _ => seqFiles
-          }
-        case _ => seqFiles
-      }
-    }
+    private def getFilesFromMainAndAllSubFolders(migrationsDir: File): Seq[File] = Path.allSubpaths(migrationsDir).map(_._1).filterNot(_.isDirectory).toSeq
 
     private def replicationOptionsWith(replicationStrategy: String, replicationFactor: Int) =
       new ReplicationOptions(Map("class" -> replicationStrategy, "replication_factor" -> replicationFactor))

--- a/src/main/scala/io/ino/sbtpillar/Plugin.scala
+++ b/src/main/scala/io/ino/sbtpillar/Plugin.scala
@@ -220,7 +220,7 @@ object Plugin extends sbt.Plugin {
 
     private def loadMigrations(migrationsDir: File) = {
       val parser = de.kaufhof.pillar.Parser()
-      Option(migrationsDir.listFiles()) match {
+      Option(migrationsDir.listFiles().filterNot(_.isDirectory)) match {
         case Some(files) => files.map { f =>
           val in = Files.newInputStream(f.toPath)
           try {


### PR DESCRIPTION
if the migrations-directory contains one or more directories,the migrate crashes because of handling a directory as file. 